### PR TITLE
Cleaning Up typing, examples, and imports

### DIFF
--- a/.github/workflows/code-coverage-workflow.yml
+++ b/.github/workflows/code-coverage-workflow.yml
@@ -27,7 +27,7 @@ jobs:
         python -m pip install -r requirements-test.txt
     - name: Test and generate coverage report
       run: |
-        python -m pytest --cov=modifiable_items_dict --cov-report=xml --doctest-modules
+        python -m pytest --cov=modifiable_items_dictionary --cov-report=xml --doctest-modules
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -26,4 +26,4 @@ jobs:
         python -m pip install -r requirements-test.txt
     - name: Test
       run: |
-        pytest --doctest-modules
+        pytest 

--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -26,4 +26,4 @@ jobs:
         python -m pip install -r requirements-test.txt
     - name: Test
       run: |
-        pytest 
+        pytest --doctest-modules

--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -26,4 +26,4 @@ jobs:
         python -m pip install -r requirements-test.txt
     - name: Test
       run: |
-        pytest --doctest-modules
+        pytest tests/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This class extends and maintains the original functionality of the builtin `dict
 ## Simple Example
 
 ```python
-import modifiable_items_dict
+import modifiable_items_dictionary
 
 
 def _add_1(_value):
@@ -40,14 +40,14 @@ def _case_fold_string(_value):
     return _value
 
 
-modifiable_items_dict.ModifiableItemsDict._key_modifiers = [str.casefold]
-modifiable_items_dict.ModifiableItemsDict._value_modifiers = (_add_1, _case_fold_string)
+modifiable_items_dictionary.ModifiableItemsDict._key_modifiers = [str.casefold]
+modifiable_items_dictionary.ModifiableItemsDict._value_modifiers = (_add_1, _case_fold_string)
 # Or
 # modifiable_items_dict.ModifiableItemsDict._key_modifiers = staticmethod(str.casefold)
 # modifiable_items_dict.ModifiableItemsDict._value_modifiers = [_case_fold_string, _add_1]
 
-modifiable_items_dictionary = modifiable_items_dict.ModifiableItemsDict({"lower": 1, "UPPER": 2}, CamelCase=3,
-                                                                        snake_case="FoUR")
+modifiable_items_dictionary = modifiable_items_dictionary.ModifiableItemsDict({"lower": 1, "UPPER": 2}, CamelCase=3,
+                                                                              snake_case="FoUR")
 
 print(modifiable_items_dictionary)  # {'lower': 2, 'upper': 3, 'camelcase': 4, 'snake_case': 'four'}
 
@@ -70,10 +70,10 @@ This example highlights how to inherit from `ModifiableItemsDict` and had key an
 ```python
 import ipaddress
 
-import modifiable_items_dict
+import modifiable_items_dictionary
 
 
-class HostDict(modifiable_items_dict.ModifiableItemsDict):
+class HostDict(modifiable_items_dictionary.ModifiableItemsDict):
     _key_modifiers = [str.casefold, str.strip]
     _value_modifiers = [ipaddress.ip_address]
     # Or
@@ -105,7 +105,7 @@ import multiprocessing.pool
 import string
 import time
 
-import modifiable_items_dict
+import modifiable_items_dictionary
 
 pool = multiprocessing.pool.ThreadPool(10)
 
@@ -115,7 +115,7 @@ def _slow_function(x):
     return x
 
 
-class TimeDictWithThreading(modifiable_items_dict.ModifiableItemsDict):
+class TimeDictWithThreading(modifiable_items_dictionary.ModifiableItemsDict):
     _key_modifiers = (_slow_function,)
     _value_modifiers = (_slow_function,)
     _map_function = pool.imap_unordered
@@ -123,7 +123,7 @@ class TimeDictWithThreading(modifiable_items_dict.ModifiableItemsDict):
     # _map_function = pool.imap
 
 
-class TimeDict(modifiable_items_dict.ModifiableItemsDict):
+class TimeDict(modifiable_items_dictionary.ModifiableItemsDict):
     _key_modifiers = (_slow_function,)
     _value_modifiers = (_slow_function,)
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,31 @@
 [![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blueviolet.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/tybruno/modifiable-items-dictionary/branch/main/graph/badge.svg?token=ZO94EJFI3G)](https://codecov.io/gh/tybruno/modifiable-items-dictionary)
+
 # modifiable-items-dict
-A simple, fast, typed, and tested implementation for a python3.6+ Modifiable Items dictionary. `ModifiableItemsDict` extends `dict` with the ability to modify key's and value's on creation, insertion, and retrieval. 
+
+A simple, fast, typed, and tested implementation for a python3.6+ Modifiable Items dictionary. `ModifiableItemsDict`
+extends `dict` with the ability to modify key's and value's on creation, insertion, and retrieval.
 This class extends and maintains the original functionality of the builtin `dict`.
 
 #### Key Features:
+
 * **Easy**: Flexable and easy to add Key and/or Value modifiers to the `ModifiableItemsDict`
 * **Great Developer Experience**: Being fully typed makes it great for editor support.
 * **Fully Tested**: Our test suit fully tests the functionality to ensure that `ModifiableItemsDict` runs as expected.
 * **There is More!!!**:
-    * [CaselessDict](https://github.com/tybruno/caseless-dictionary): `CaselessDict` extends `ModifiableItemsDict` which is a `CaselessDict` which ignores the case of the keys.
+    * [CaselessDict](https://github.com/tybruno/caseless-dictionary): `CaselessDict` extends `ModifiableItemsDict` which
+      is a `CaselessDict` which ignores the case of the keys.
 
 ## Installation
+
 `pip install modifiable-items-dictionary`
 
 ## Simple Example
+
 ```python
 from modifiable_items_dict import ModifiableItemsDict
+
 
 def _add_1(_value):
     if isinstance(_value, int):
@@ -32,9 +40,9 @@ ModifiableItemsDict._value_modifiers = (str.casefold, _add_1)
 # ModifiableItemsDict._key_modifiers = staticmethod(_lower)
 # ModifiableItemsDict._value_modifiers = [_lower, _add_1]
 
-modifiable_items_dict = ModifiableItemsDict({"lower":1, "UPPER":2 }, CamelCase=3, snake_case="FoUR")
+modifiable_items_dict = ModifiableItemsDict({"lower": 1, "UPPER": 2}, CamelCase=3, snake_case="FoUR")
 
-print(modifiable_items_dict) # {'lower': 2, 'upper': 3, 'camelcase': 4, 'snake_case': 'four'}
+print(modifiable_items_dict)  # {'lower': 2, 'upper': 3, 'camelcase': 4, 'snake_case': 'four'}
 
 del modifiable_items_dict["LOWER"]
 del modifiable_items_dict["UPPER"]
@@ -42,12 +50,15 @@ modifiable_items_dict.pop("SNAKE_CAse")
 
 modifiable_items_dict["HeLLO"] = 5
 
-print(modifiable_items_dict) # {'camelcase': 4, 'hello': 6}
+print(modifiable_items_dict)  # {'camelcase': 4, 'hello': 6}
 
 ```
+
 ## Example
-Let's say that there is a `.json` file that has Url hosts and their IP address. 
-Our Goal is to load the json data into a dictionary like structure that will have it's items modified during creation, insertion, and retrieval. 
+
+Let's say that there is a `.json` file that has Url hosts and their IP address.
+Our Goal is to load the json data into a dictionary like structure that will have it's items modified during creation,
+insertion, and retrieval.
 This example highlights how to inherit from `ModifiableItemsDict` and had key and value modifiers.
 
 ```python
@@ -57,13 +68,13 @@ import modifiable_items_dict
 
 
 class HostDict(modifiable_items_dict.ModifiableItemsDict):
-  _key_modifiers = [str.casefold, str.strip]
-  _value_modifiers = [ipaddress.ip_address]
-  # Or
-  # _value_modifiers = @staticmethod(ipaddress.ip_address)
+    _key_modifiers = [str.casefold, str.strip]
+    _value_modifiers = [ipaddress.ip_address]
+    # Or
+    # _value_modifiers = @staticmethod(ipaddress.ip_address)
+
 
 browsers = HostDict({"  GooGle.com    ": "142.250.69.206", " duckDUCKGo.cOM   ": "52.250.42.157"})
-
 
 print(browsers)  # {'google.com': IPv4Address('142.250.69.206'), 'duckduckgo.com': IPv4Address('52.250.42.157')}
 
@@ -73,11 +84,13 @@ _old_browser = browsers.pop("  gOOgle.com  ")
 
 browsers["   BrAvE.com   "] = "2600:9000:234c:5a00:6:d0d2:780:93a1"
 
-print(browsers)  # {'duckduckgo.com': IPv4Address('52.250.42.157'), 'brave.com': IPv6Address('2600:9000:234c:5a00:6:d0d2:780:93a1')}
+print(
+    browsers)  # {'duckduckgo.com': IPv4Address('52.250.42.157'), 'brave.com': IPv6Address('2600:9000:234c:5a00:6:d0d2:780:93a1')}
 ```
 
 ### Threading Example
-It is easy to add Threading to a `ModifiableItemsDict`. 
+
+It is easy to add Threading to a `ModifiableItemsDict`.
 
 *NOTE: Since `ModifiableItemsDict` is not pickable it does not work with Multiprocessing.*
 
@@ -92,21 +105,21 @@ pool = multiprocessing.pool.ThreadPool(10)
 
 
 def _slow_function(x):
-  time.sleep(.05)
-  return x
+    time.sleep(.05)
+    return x
 
 
 class TimeDictWithThreading(modifiable_items_dict.ModifiableItemsDict):
-  _key_modifiers = (_slow_function,)
-  _value_modifiers = (_slow_function,)
-  _map_function = pool.imap_unordered
-  # or if order matters
-  # _map_function = pool.imap
+    _key_modifiers = (_slow_function,)
+    _value_modifiers = (_slow_function,)
+    _map_function = pool.imap_unordered
+    # or if order matters
+    # _map_function = pool.imap
 
 
 class TimeDict(modifiable_items_dict.ModifiableItemsDict):
-  _key_modifiers = (_slow_function,)
-  _value_modifiers = (_slow_function,)
+    _key_modifiers = (_slow_function,)
+    _value_modifiers = (_slow_function,)
 
 
 iterable = {_letter: _index for _index, _letter in enumerate(string.ascii_letters)}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This class extends and maintains the original functionality of the builtin `dict
 ## Simple Example
 
 ```python
-from modifiable_items_dict import ModifiableItemsDict
+import modifiable_items_dict
 
 
 def _add_1(_value):
@@ -34,24 +34,30 @@ def _add_1(_value):
     return _value
 
 
-ModifiableItemsDict._key_modifiers = [str.casefold]
-ModifiableItemsDict._value_modifiers = (str.casefold, _add_1)
+def _case_fold_string(_value):
+    if isinstance(_value, str):
+        _value = _value.casefold()
+    return _value
+
+
+modifiable_items_dict.ModifiableItemsDict._key_modifiers = [str.casefold]
+modifiable_items_dict.ModifiableItemsDict._value_modifiers = (_add_1, _case_fold_string)
 # Or
-# ModifiableItemsDict._key_modifiers = staticmethod(_lower)
-# ModifiableItemsDict._value_modifiers = [_lower, _add_1]
+# modifiable_items_dict.ModifiableItemsDict._key_modifiers = staticmethod(str.casefold)
+# modifiable_items_dict.ModifiableItemsDict._value_modifiers = [_case_fold_string, _add_1]
 
-modifiable_items_dict = ModifiableItemsDict({"lower": 1, "UPPER": 2}, CamelCase=3, snake_case="FoUR")
+modifiable_items_dictionary = modifiable_items_dict.ModifiableItemsDict({"lower": 1, "UPPER": 2}, CamelCase=3,
+                                                                        snake_case="FoUR")
 
-print(modifiable_items_dict)  # {'lower': 2, 'upper': 3, 'camelcase': 4, 'snake_case': 'four'}
+print(modifiable_items_dictionary)  # {'lower': 2, 'upper': 3, 'camelcase': 4, 'snake_case': 'four'}
 
-del modifiable_items_dict["LOWER"]
-del modifiable_items_dict["UPPER"]
-modifiable_items_dict.pop("SNAKE_CAse")
+del modifiable_items_dictionary["LOWER"]
+del modifiable_items_dictionary["UPPER"]
+modifiable_items_dictionary.pop("SNAKE_CAse")
 
-modifiable_items_dict["HeLLO"] = 5
+modifiable_items_dictionary["HeLLO"] = 5
 
-print(modifiable_items_dict)  # {'camelcase': 4, 'hello': 6}
-
+print(modifiable_items_dictionary)  # {'camelcase': 4, 'hello': 6}
 ```
 
 ## Example

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -2,6 +2,7 @@ import ipaddress
 import multiprocessing.pool
 import string
 import time
+
 import modifiable_items_dict
 
 
@@ -9,6 +10,7 @@ def simple_inheritance_example():
     """This example shows how to create a Host Dictionary that will casefold keys, strip keys, and convert values to ip addresses
 
     """
+
     # Inherit from `ModifiableItemsDict` and set the `_key_modifiers` and `_value_modifiers` class variables.
     class HostDict(modifiable_items_dict.ModifiableItemsDict):
         _key_modifiers = [str.casefold, str.strip]
@@ -26,7 +28,10 @@ def simple_inheritance_example():
 
     browsers["   BrAvE.com   "] = "2600:9000:234c:5a00:6:d0d2:780:93a1"
 
-    print(browsers)  # {'duckduckgo.com': IPv4Address('52.250.42.157'), 'brave.com': IPv6Address('2600:9000:234c:5a00:6:d0d2:780:93a1')}
+    print(
+        browsers)
+    # {'duckduckgo.com': IPv4Address('52.250.42.157'), 'brave.com': IPv6Address('2600:9000:234c:5a00:6:d0d2:780:93a1')}
+
 
 def threading_example():
     """This example shows how to use Threading with `ModifiableItemsDict`."""

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -6,6 +6,39 @@ import time
 import modifiable_items_dict
 
 
+def simple_example():
+    import modifiable_items_dict
+
+    def _add_1(_value):
+        if isinstance(_value, int):
+            _value += 1
+        return _value
+
+    def _case_fold_string(_value):
+        if isinstance(_value, str):
+            _value = _value.casefold()
+        return _value
+
+    modifiable_items_dict.ModifiableItemsDict._key_modifiers = [str.casefold]
+    modifiable_items_dict.ModifiableItemsDict._value_modifiers = (_add_1, _case_fold_string)
+    # Or
+    # modifiable_items_dict.ModifiableItemsDict._key_modifiers = staticmethod(_lower)
+    # modifiable_items_dict.ModifiableItemsDict._value_modifiers = [_lower, _add_1]
+
+    modifiable_items_dictionary = modifiable_items_dict.ModifiableItemsDict({"lower": 1, "UPPER": 2}, CamelCase=3,
+                                                                            snake_case="FoUR")
+
+    print(modifiable_items_dictionary)  # {'lower': 2, 'upper': 3, 'camelcase': 4, 'snake_case': 'four'}
+
+    del modifiable_items_dictionary["LOWER"]
+    del modifiable_items_dictionary["UPPER"]
+    modifiable_items_dictionary.pop("SNAKE_CAse")
+
+    modifiable_items_dictionary["HeLLO"] = 5
+
+    print(modifiable_items_dictionary)  # {'camelcase': 4, 'hello': 6}
+
+
 def simple_inheritance_example():
     """This example shows how to create a Host Dictionary that will casefold keys, strip keys, and convert values to ip addresses
 
@@ -66,3 +99,13 @@ def threading_example():
     TimeDictWithThreading(iterable)
     end = time.perf_counter()
     print(f"{end - start:.2f} seconds")  # 0.64 seconds
+
+
+def main():
+    simple_example()
+    simple_inheritance_example()
+    threading_example()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -1,0 +1,63 @@
+import ipaddress
+import multiprocessing.pool
+import string
+import time
+import modifiable_items_dict
+
+
+def simple_inheritance_example():
+    """This example shows how to create a Host Dictionary that will casefold keys, strip keys, and convert values to ip addresses
+
+    """
+    # Inherit from `ModifiableItemsDict` and set the `_key_modifiers` and `_value_modifiers` class variables.
+    class HostDict(modifiable_items_dict.ModifiableItemsDict):
+        _key_modifiers = [str.casefold, str.strip]
+        _value_modifiers = [ipaddress.ip_address]
+        # Or
+        # _value_modifiers = @staticmethod(ipaddress.ip_address)
+
+    browsers = HostDict({"  GooGle.com    ": "142.250.69.206", " duckDUCKGo.cOM   ": "52.250.42.157"})
+
+    print(browsers)  # {'google.com': IPv4Address('142.250.69.206'), 'duckduckgo.com': IPv4Address('52.250.42.157')}
+
+    _old_browser = browsers.pop("  gOOgle.com  ")
+    # or
+    # del host_dict["   GooGle.com  "]
+
+    browsers["   BrAvE.com   "] = "2600:9000:234c:5a00:6:d0d2:780:93a1"
+
+    print(browsers)  # {'duckduckgo.com': IPv4Address('52.250.42.157'), 'brave.com': IPv6Address('2600:9000:234c:5a00:6:d0d2:780:93a1')}
+
+def threading_example():
+    """This example shows how to use Threading with `ModifiableItemsDict`."""
+
+    pool = multiprocessing.pool.ThreadPool(10)
+
+    def _slow_function(x):
+        time.sleep(.05)
+        return x
+
+    class TimeDictWithThreading(modifiable_items_dict.ModifiableItemsDict):
+        _key_modifiers = (_slow_function,)
+        _value_modifiers = (_slow_function,)
+        _map_function = pool.imap_unordered
+        # or if order matters
+        # _map_function = pool.imap
+
+    class TimeDict(modifiable_items_dict.ModifiableItemsDict):
+        _key_modifiers = (_slow_function,)
+        _value_modifiers = (_slow_function,)
+
+    iterable = {_letter: _index for _index, _letter in enumerate(string.ascii_letters)}
+
+    # Without Threading
+    start = time.perf_counter()
+    TimeDict(iterable)
+    end = time.perf_counter()
+    print(f"{end - start:.2f} seconds")  # 5.54 seconds
+
+    # With Threading
+    start = time.perf_counter()
+    TimeDictWithThreading(iterable)
+    end = time.perf_counter()
+    print(f"{end - start:.2f} seconds")  # 0.64 seconds

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -3,11 +3,11 @@ import multiprocessing.pool
 import string
 import time
 
-import modifiable_items_dict
+import modifiable_items_dictionary
 
 
 def simple_example():
-    import modifiable_items_dict
+    import modifiable_items_dictionary
 
     def _add_1(_value):
         if isinstance(_value, int):
@@ -19,24 +19,24 @@ def simple_example():
             _value = _value.casefold()
         return _value
 
-    modifiable_items_dict.ModifiableItemsDict._key_modifiers = [str.casefold]
-    modifiable_items_dict.ModifiableItemsDict._value_modifiers = (_add_1, _case_fold_string)
+    modifiable_items_dictionary.ModifiableItemsDict._key_modifiers = [str.casefold]
+    modifiable_items_dictionary.ModifiableItemsDict._value_modifiers = (_add_1, _case_fold_string)
     # Or
     # modifiable_items_dict.ModifiableItemsDict._key_modifiers = staticmethod(_lower)
     # modifiable_items_dict.ModifiableItemsDict._value_modifiers = [_lower, _add_1]
 
-    modifiable_items_dictionary = modifiable_items_dict.ModifiableItemsDict({"lower": 1, "UPPER": 2}, CamelCase=3,
-                                                                            snake_case="FoUR")
+    modifiable_items_dict = modifiable_items_dictionary.ModifiableItemsDict({"lower": 1, "UPPER": 2}, CamelCase=3,
+                                                                                  snake_case="FoUR")
 
-    print(modifiable_items_dictionary)  # {'lower': 2, 'upper': 3, 'camelcase': 4, 'snake_case': 'four'}
+    print(modifiable_items_dict)  # {'lower': 2, 'upper': 3, 'camelcase': 4, 'snake_case': 'four'}
 
     del modifiable_items_dictionary["LOWER"]
     del modifiable_items_dictionary["UPPER"]
-    modifiable_items_dictionary.pop("SNAKE_CAse")
+    modifiable_items_dict.pop("SNAKE_CAse")
 
-    modifiable_items_dictionary["HeLLO"] = 5
+    modifiable_items_dict["HeLLO"] = 5
 
-    print(modifiable_items_dictionary)  # {'camelcase': 4, 'hello': 6}
+    print(modifiable_items_dict)  # {'camelcase': 4, 'hello': 6}
 
 
 def simple_inheritance_example():
@@ -45,7 +45,7 @@ def simple_inheritance_example():
     """
 
     # Inherit from `ModifiableItemsDict` and set the `_key_modifiers` and `_value_modifiers` class variables.
-    class HostDict(modifiable_items_dict.ModifiableItemsDict):
+    class HostDict(modifiable_items_dictionary.ModifiableItemsDict):
         _key_modifiers = [str.casefold, str.strip]
         _value_modifiers = [ipaddress.ip_address]
         # Or
@@ -75,14 +75,14 @@ def threading_example():
         time.sleep(.05)
         return x
 
-    class TimeDictWithThreading(modifiable_items_dict.ModifiableItemsDict):
+    class TimeDictWithThreading(modifiable_items_dictionary.ModifiableItemsDict):
         _key_modifiers = (_slow_function,)
         _value_modifiers = (_slow_function,)
         _map_function = pool.imap_unordered
         # or if order matters
         # _map_function = pool.imap
 
-    class TimeDict(modifiable_items_dict.ModifiableItemsDict):
+    class TimeDict(modifiable_items_dictionary.ModifiableItemsDict):
         _key_modifiers = (_slow_function,)
         _value_modifiers = (_slow_function,)
 

--- a/modifiable_items_dict/__init__.py
+++ b/modifiable_items_dict/__init__.py
@@ -1,3 +1,0 @@
-from modifiable_items_dict.modifiable_items_dict import ModifiableItemsDict
-
-__all__ = (ModifiableItemsDict.__name__,)

--- a/modifiable_items_dict/modifiable_items_dict.py
+++ b/modifiable_items_dict/modifiable_items_dict.py
@@ -3,8 +3,8 @@ Modifiable Items Dictionary and related objects.
 
 Example:
     >>> import ipaddress
-    >>> import modifiable_items_dict
-    >>> class HostDict(modifiable_items_dict.ModifiableItemsDict):
+    >>> from modifiable_items_dict.modifiable_items_dict import modifiable_items_dict
+    >>> class HostDict(ModifiableItemsDict):
     ...     _key_modifiers = (str.casefold, str.strip)
     ...     _value_modifiers = [ipaddress.ip_address]
     >>> browsers = HostDict({"  GooGle.com    ": "142.250.69.206", " duckDUCKGo.cOM   ": "52.250.42.157"})

--- a/modifiable_items_dict/modifiable_items_dict.py
+++ b/modifiable_items_dict/modifiable_items_dict.py
@@ -1,6 +1,21 @@
 """
 Modifiable Items Dictionary and related objects.
 
+Example:
+    >>> import ipaddress
+    >>> import modifiable_items_dict
+    >>> class HostDict(modifiable_items_dict.ModifiableItemsDict):
+    ...     _key_modifiers = (str.casefold, str.strip)
+    ...     _value_modifiers = [ipaddress.ip_address]
+    >>> browsers = HostDict({"  GooGle.com    ": "142.250.69.206", " duckDUCKGo.cOM   ": "52.250.42.157"})
+    >>> browsers
+    {'google.com': IPv4Address('142.250.69.206'), 'duckduckgo.com': IPv4Address('52.250.42.157')}
+    >>> _old_browser = browsers.pop("  gOOgle.Com  ")
+    >>> browsers["   BrAvE.com   "] = "2600:9000:234c:5a00:6:d0d2:780:93a1"
+    >>> browsers
+    {'duckduckgo.com': IPv4Address('52.250.42.157'), 'brave.com': IPv6Address('2600:9000:234c:5a00:6:d0d2:780:93a1')}
+
+    return _value
 Objects provided by this module:
    `ModifiableItemsDict` - Adds the ability to modify key's and value's on creation, insertion, and retrieval
 """

--- a/modifiable_items_dict/modifiable_items_dict.py
+++ b/modifiable_items_dict/modifiable_items_dict.py
@@ -3,8 +3,8 @@ Modifiable Items Dictionary and related objects.
 
 Example:
     >>> import ipaddress
-    >>> from modifiable_items_dict.modifiable_items_dict import modifiable_items_dict
-    >>> class HostDict(ModifiableItemsDict):
+    >>> import modifiable_items_dict
+    >>> class HostDict(modifiable_items_dict.ModifiableItemsDict):
     ...     _key_modifiers = (str.casefold, str.strip)
     ...     _value_modifiers = [ipaddress.ip_address]
     >>> browsers = HostDict({"  GooGle.com    ": "142.250.69.206", " duckDUCKGo.cOM   ": "52.250.42.157"})

--- a/modifiable_items_dict/modifiable_items_dict.py
+++ b/modifiable_items_dict/modifiable_items_dict.py
@@ -27,6 +27,9 @@ import typing
 NO_DEFAULT = object()
 
 # Typing
+# For python 3.6 compatibility
+Self = typing.TypeVar("Self", bound="ModifiableItemsDict")
+
 Key = typing.Hashable
 Value = typing.Any
 MappingCallable = typing.Union[
@@ -35,10 +38,10 @@ MappingCallable = typing.Union[
 KeyCallable = typing.Callable[[typing.Any], Key]
 ValueCallable = typing.Callable[[typing.Any], Value]
 KeyModifiers = typing.Optional[
-    typing.Union[typing.Self, KeyCallable, typing.Iterable[KeyCallable], None]
+    typing.Union[Self, KeyCallable, typing.Iterable[KeyCallable], None]
 ]
 ValueModifiers = typing.Optional[
-    typing.Union[typing.Self, ValueCallable, typing.Iterable[ValueCallable], None]
+    typing.Union[Self, ValueCallable, typing.Iterable[ValueCallable], None]
 ]
 
 

--- a/modifiable_items_dict/modifiable_items_dict.py
+++ b/modifiable_items_dict/modifiable_items_dict.py
@@ -208,7 +208,7 @@ class ModifiableItemsDict(dict):
             cls,
             __iterable: typing.Iterable[Key],
             __value: typing.Optional[typing.Union[Value, None]] = None,
-    ) -> typing.Self:
+    ) -> Self:
         return cls(dict.fromkeys(__iterable, __value))
 
     @typing.overload

--- a/modifiable_items_dict/modifiable_items_dict.py
+++ b/modifiable_items_dict/modifiable_items_dict.py
@@ -5,20 +5,8 @@ Objects provided by this module:
    `ModifiableItemsDict` - Adds the ability to modify key's and value's on creation, insertion, and retrieval
 """
 import contextlib
-from multiprocessing.pool import ThreadPool
-from typing import (
-    Any,
-    Callable,
-    Hashable,
-    Iterable,
-    Mapping,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-    overload,
-    ItemsView,
-)
+import multiprocessing.pool
+import typing
 
 # Sentinel
 _OPTIONAL = object()

--- a/modifiable_items_dict/modifiable_items_dict.py
+++ b/modifiable_items_dict/modifiable_items_dict.py
@@ -9,28 +9,21 @@ import multiprocessing.pool
 import typing
 
 # Sentinel
-_OPTIONAL = object()
+NO_DEFAULT = object()
 
 # Typing
-_SELF = TypeVar("_SELF", bound="ModifiableItemsDict")
-
-_TYPE = TypeVar("_TYPE")
-
-_MAP_FUNCTION = Union[
-    map, ThreadPool.map, ThreadPool.imap, ThreadPool.imap_unordered
+Key = typing.Hashable
+Value = typing.Any
+MappingCallable = typing.Union[
+    map, multiprocessing.pool.ThreadPool.map, multiprocessing.pool.ThreadPool.imap, multiprocessing.pool.ThreadPool.imap_unordered
 ]
-
-_KEY = Hashable
-_VALUE = Any
-
-_KEY_CALLABLE = Callable[[Any], _KEY]
-_VALUE_CALLABLE = Callable[[Any], _VALUE]
-
-_KEY_MODIFIERS = Optional[
-    Union[_SELF, _KEY_CALLABLE, Iterable[_KEY_CALLABLE], None]
+KeyCallable = typing.Callable[[typing.Any], Key]
+ValueCallable = typing.Callable[[typing.Any], Value]
+KeyModifiers = typing.Optional[
+    typing.Union[typing.Self, KeyCallable, typing.Iterable[KeyCallable], None]
 ]
-_VALUE_MODIFIERS = Optional[
-    Union[_SELF, _VALUE_CALLABLE, Iterable[_VALUE_CALLABLE], None]
+ValueModifiers = typing.Optional[
+    typing.Union[typing.Self, ValueCallable, typing.Iterable[ValueCallable], None]
 ]
 
 
@@ -54,21 +47,21 @@ class ModifiableItemsDict(dict):
     __slots__ = ()
 
     # TODO: Add validators
-    _key_modifiers: _KEY_MODIFIERS = None
-    _value_modifiers: _VALUE_MODIFIERS = None
-    _map_function: _MAP_FUNCTION = map
+    _key_modifiers: KeyModifiers = None
+    _value_modifiers: ValueModifiers = None
+    _map_function: MappingCallable = map
 
     @staticmethod
     def _modify_item(
-        item: Any,
-        modifiers: Union[
-            Iterable[Callable[[Any], Hashable]],
-            Iterable[Callable[[Any], Any]],
-            Callable[[Any], Hashable],
-            Callable[[Any], Any],
+        item: typing.Any,
+        modifiers: typing.Union[
+            typing.Iterable[typing.Callable[[typing.Any], typing.Hashable]],
+            typing.Iterable[typing.Callable[[typing.Any], typing.Any]],
+            typing.Callable[[typing.Any], typing.Hashable],
+            typing.Callable[[typing.Any], typing.Any],
             None,
         ],
-    ) -> Any:
+    ) -> typing.Any:
         """Modifies an *__item* with the *modifiers*
 
         Args:
@@ -91,7 +84,7 @@ class ModifiableItemsDict(dict):
             )
             raise _error
 
-        if isinstance(modifiers, Iterable):
+        if isinstance(modifiers, typing.Iterable):
             for modifier in modifiers:
                 item = modifier(item)
             return item
@@ -103,11 +96,11 @@ class ModifiableItemsDict(dict):
             "Invalid Modifiers:",
             modifiers,
             "must be of types:",
-            (Iterable, Callable),
+            (typing.Iterable, typing.Callable),
         )
         raise _error
 
-    def _modify_key(self, key: _KEY) -> _KEY:
+    def _modify_key(self, key: Key) -> Key:
         """Modify the *__key* with the __key modifiers.
 
         Args:
@@ -116,10 +109,10 @@ class ModifiableItemsDict(dict):
         Returns:
             The modified *__key*.
         """
-        _modified_key: _KEY = self._modify_item(key, self._key_modifiers)
+        _modified_key: Key = self._modify_item(key, self._key_modifiers)
         return _modified_key
 
-    def _modify_value(self, value: _VALUE) -> _VALUE:
+    def _modify_value(self, value: Value) -> Value:
         """Modify the *v* with the v modifiers.
 
         Args:
@@ -128,14 +121,14 @@ class ModifiableItemsDict(dict):
         Returns:
             The modified *v*
         """
-        _modified_value: _VALUE = self._modify_item(
+        _modified_value: Value = self._modify_item(
             value, self._value_modifiers
         )
         return _modified_value
 
     def _modify_key_and_item(
-        self, key_and_value: Tuple[_KEY, _VALUE]
-    ) -> Tuple[_KEY, _VALUE]:
+        self, key_and_value: typing.Tuple[Key, Value]
+    ) -> typing.Tuple[Key, Value]:
         _key, _value = key_and_value
         if self._key_modifiers:
             _key = self._modify_key(_key)
@@ -143,16 +136,16 @@ class ModifiableItemsDict(dict):
             _value = self._modify_value(_value)
         return _key, _value
 
-    @overload
+    @typing.overload
     def _create_modified_mapping(
-        self, items_view: ItemsView[_KEY, _VALUE]
-    ) -> Mapping[_KEY, _VALUE]:
+        self, items_view: typing.ItemsView[Key, Value]
+    ) -> typing.Mapping[Key, Value]:
         ...
 
-    @overload
+    @typing.overload
     def _create_modified_mapping(
-        self, iterable: Iterable[Tuple[_KEY, _VALUE]]
-    ) -> Mapping[_KEY, _VALUE]:
+        self, iterable: typing.Iterable[typing.Tuple[Key, Value]]
+    ) -> typing.Mapping[Key, Value]:
         ...
 
     def _create_modified_mapping(self, iterable):
@@ -165,7 +158,7 @@ class ModifiableItemsDict(dict):
             Dictionary with the modified keys and values.
         """
 
-        new_mapping: Mapping[_KEY, _VALUE] = {
+        new_mapping: typing.Mapping[Key, Value] = {
             key: value
             for key, value in self._map_function(
                 self._modify_key_and_item, iterable
@@ -175,8 +168,8 @@ class ModifiableItemsDict(dict):
         return new_mapping
 
     def _iterable_to_modified_dict(
-        self, iterable: Iterable
-    ) -> Mapping[_KEY, _VALUE]:
+        self, iterable: typing.Iterable
+    ) -> typing.Mapping[Key, Value]:
         """Convert an *iterable* to a *Mapping* that has had it's keys and values modified.
 
         Args:
@@ -185,9 +178,9 @@ class ModifiableItemsDict(dict):
         Returns:
             Modified Mapping of the items.
         """
-        if isinstance(iterable, Mapping):
+        if isinstance(iterable, typing.Mapping):
             iterable = self._create_modified_mapping(iterable.items())
-        elif isinstance(iterable, Iterable):
+        elif isinstance(iterable, typing.Iterable):
             iterable = self._create_modified_mapping(iterable)
 
         return iterable
@@ -195,24 +188,24 @@ class ModifiableItemsDict(dict):
     @classmethod
     def fromkeys(
         cls,
-        __iterable: Iterable[_KEY],
-        __value: Optional[Union[_VALUE, None]] = None,
-    ) -> _SELF:
+        __iterable: typing.Iterable[Key],
+        __value: typing.Optional[typing.Union[Value, None]] = None,
+    ) -> typing.Self:
         return cls(dict.fromkeys(__iterable, __value))
 
-    @overload
-    def __init__(self, **kwargs: _VALUE) -> None:
+    @typing.overload
+    def __init__(self, **kwargs: Value) -> None:
         ...
 
-    @overload
+    @typing.overload
     def __init__(
-        self, mapping: Mapping[_KEY, _VALUE], **kwargs: _VALUE
+        self, mapping: typing.Mapping[Key, Value], **kwargs: Value
     ) -> None:
         ...
 
-    @overload
+    @typing.overload
     def __init__(
-        self, iterable: Iterable[Tuple[str, Any]], **kwargs: _VALUE
+        self, iterable: typing.Iterable[typing.Tuple[str, typing.Any]], **kwargs: Value
     ) -> None:
         ...
 
@@ -230,72 +223,72 @@ class ModifiableItemsDict(dict):
 
         dict.__init__(self, iterable or dict(), **kwargs)
 
-    def __getitem__(self, k: _KEY) -> Any:
+    def __getitem__(self, k: Key) -> typing.Any:
         k = self._modify_key(k)
         return dict.__getitem__(self, k)
 
-    def __setitem__(self, k: _KEY, v: _VALUE) -> None:
+    def __setitem__(self, k: Key, v: Value) -> None:
         k = self._modify_key(k)
         v = self._modify_value(v)
         dict.__setitem__(self, k, v)
 
-    def __delitem__(self, v: _KEY) -> None:
+    def __delitem__(self, v: Key) -> None:
         v = self._modify_key(v)
         dict.__delitem__(self, v)
 
-    def __contains__(self, __item: _VALUE) -> bool:
+    def __contains__(self, __item: Value) -> bool:
         __item = self._modify_key(__item)
         _is_in: bool = dict.__contains__(self, __item)
         return _is_in
 
-    def setdefault(self, __key: _KEY, __default: _VALUE = None) -> None:
+    def setdefault(self, __key: Key, __default: Value = None) -> None:
         __key = self._modify_key(__key)
         __default = self._modify_value(__default)
         dict.setdefault(self, __key, __default)
 
-    @overload
-    def pop(self, __key: _KEY) -> _VALUE:
+    @typing.overload
+    def pop(self, __key: Key) -> Value:
         ...
 
-    @overload
-    def pop(self, __key: _KEY, default: _VALUE = ...) -> _VALUE:
+    @typing.overload
+    def pop(self, __key: Key, default: Value = ...) -> Value:
         ...
 
-    def pop(self, __key, default=_OPTIONAL) -> _VALUE:
+    def pop(self, __key, default=NO_DEFAULT) -> Value:
         __key = self._modify_key(__key)
 
-        if default is _OPTIONAL:
-            value: _VALUE = dict.pop(self, __key)
+        if default is NO_DEFAULT:
+            value: Value = dict.pop(self, __key)
         else:
-            value: _VALUE = dict.pop(self, __key, default)
+            value: Value = dict.pop(self, __key, default)
 
         return value
 
-    @overload
-    def get(self, __key: _KEY) -> Union[_VALUE, None]:
+    @typing.overload
+    def get(self, __key: Key) -> typing.Union[Value, None]:
         ...
 
-    @overload
-    def get(self, __key: _KEY, default: _VALUE = None) -> _VALUE:
+    @typing.overload
+    def get(self, __key: Key, default: Value = None) -> Value:
         ...
 
-    def get(self, __key: _KEY, default=None):
+    def get(self, __key: Key, default=None):
         __key = self._modify_key(__key)
-        value: Union[_VALUE, None] = dict.get(self, __key, default)
+        value: typing.Union[Value, None] = dict.get(self, __key, default)
         return value
 
-    @overload
-    def update(self, __m: Mapping[_KEY, _VALUE], **kwargs: _VALUE) -> None:
+    @typing.overload
+    def update(self, __m: typing.Mapping[Key, Value], **kwargs: Value) -> None:
         ...
 
-    @overload
+    @typing.overload
     def update(
-        self, __m: Iterable[Tuple[str, Any]], **kwargs: _VALUE
+        self, __m: typing.Iterable[typing.Tuple[str, typing.Any]], **kwargs: Value
     ) -> None:
         ...
 
-    @overload
-    def update(self, **kwargs: _VALUE) -> None:
+    @typing.overload
+    def update(self, **kwargs: Value) -> None:
         ...
 
     def update(

--- a/modifiable_items_dict/modifiable_items_dict.py
+++ b/modifiable_items_dict/modifiable_items_dict.py
@@ -68,14 +68,14 @@ class ModifiableItemsDict(dict):
 
     @staticmethod
     def _modify_item(
-        item: typing.Any,
-        modifiers: typing.Union[
-            typing.Iterable[typing.Callable[[typing.Any], typing.Hashable]],
-            typing.Iterable[typing.Callable[[typing.Any], typing.Any]],
-            typing.Callable[[typing.Any], typing.Hashable],
-            typing.Callable[[typing.Any], typing.Any],
-            None,
-        ],
+            item: typing.Any,
+            modifiers: typing.Union[
+                typing.Iterable[typing.Callable[[typing.Any], typing.Hashable]],
+                typing.Iterable[typing.Callable[[typing.Any], typing.Any]],
+                typing.Callable[[typing.Any], typing.Hashable],
+                typing.Callable[[typing.Any], typing.Any],
+                None,
+            ],
     ) -> typing.Any:
         """Modifies an *__item* with the *modifiers*
 
@@ -142,7 +142,7 @@ class ModifiableItemsDict(dict):
         return _modified_value
 
     def _modify_key_and_item(
-        self, key_and_value: typing.Tuple[Key, Value]
+            self, key_and_value: typing.Tuple[Key, Value]
     ) -> typing.Tuple[Key, Value]:
         _key, _value = key_and_value
         if self._key_modifiers:
@@ -153,13 +153,13 @@ class ModifiableItemsDict(dict):
 
     @typing.overload
     def _create_modified_mapping(
-        self, items_view: typing.ItemsView[Key, Value]
+            self, items_view: typing.ItemsView[Key, Value]
     ) -> typing.Mapping[Key, Value]:
         ...
 
     @typing.overload
     def _create_modified_mapping(
-        self, iterable: typing.Iterable[typing.Tuple[Key, Value]]
+            self, iterable: typing.Iterable[typing.Tuple[Key, Value]]
     ) -> typing.Mapping[Key, Value]:
         ...
 
@@ -183,7 +183,7 @@ class ModifiableItemsDict(dict):
         return new_mapping
 
     def _iterable_to_modified_dict(
-        self, iterable: typing.Iterable
+            self, iterable: typing.Iterable
     ) -> typing.Mapping[Key, Value]:
         """Convert an *iterable* to a *Mapping* that has had it's keys and values modified.
 
@@ -202,9 +202,9 @@ class ModifiableItemsDict(dict):
 
     @classmethod
     def fromkeys(
-        cls,
-        __iterable: typing.Iterable[Key],
-        __value: typing.Optional[typing.Union[Value, None]] = None,
+            cls,
+            __iterable: typing.Iterable[Key],
+            __value: typing.Optional[typing.Union[Value, None]] = None,
     ) -> typing.Self:
         return cls(dict.fromkeys(__iterable, __value))
 
@@ -214,20 +214,20 @@ class ModifiableItemsDict(dict):
 
     @typing.overload
     def __init__(
-        self, mapping: typing.Mapping[Key, Value], **kwargs: Value
+            self, mapping: typing.Mapping[Key, Value], **kwargs: Value
     ) -> None:
         ...
 
     @typing.overload
     def __init__(
-        self, iterable: typing.Iterable[typing.Tuple[str, typing.Any]], **kwargs: Value
+            self, iterable: typing.Iterable[typing.Tuple[str, typing.Any]], **kwargs: Value
     ) -> None:
         ...
 
     def __init__(
-        self,
-        iterable=None,
-        **kwargs,
+            self,
+            iterable=None,
+            **kwargs,
     ):
         # If there is a ValueError have the inherited class deal with it.
         with contextlib.suppress(ValueError):
@@ -298,7 +298,7 @@ class ModifiableItemsDict(dict):
 
     @typing.overload
     def update(
-        self, __m: typing.Iterable[typing.Tuple[str, typing.Any]], **kwargs: Value
+            self, __m: typing.Iterable[typing.Tuple[str, typing.Any]], **kwargs: Value
     ) -> None:
         ...
 
@@ -307,9 +307,9 @@ class ModifiableItemsDict(dict):
         ...
 
     def update(
-        self,
-        __m=None,
-        **kwargs,
+            self,
+            __m=None,
+            **kwargs,
     ):
         # If there is a ValueError have the inherited class deal with it.
         with contextlib.suppress(ValueError):

--- a/modifiable_items_dictionary/__init__.py
+++ b/modifiable_items_dictionary/__init__.py
@@ -1,0 +1,3 @@
+from modifiable_items_dictionary.modifiable_items_dictionary import ModifiableItemsDict
+
+__all__ = (ModifiableItemsDict.__name__,)

--- a/modifiable_items_dictionary/modifiable_items_dictionary.py
+++ b/modifiable_items_dictionary/modifiable_items_dictionary.py
@@ -14,7 +14,6 @@ Example:
     >>> browsers
     {'duckduckgo.com': IPv4Address('52.250.42.157'), 'brave.com': IPv6Address('2600:9000:234c:5a00:6:d0d2:780:93a1')}
 
-    return _value
 Objects provided by this module:
    `ModifiableItemsDict` - Adds the ability to modify key's and value's on creation, insertion, and retrieval
 """

--- a/modifiable_items_dictionary/modifiable_items_dictionary.py
+++ b/modifiable_items_dictionary/modifiable_items_dictionary.py
@@ -3,8 +3,8 @@ Modifiable Items Dictionary and related objects.
 
 Example:
     >>> import ipaddress
-    >>> import modifiable_items_dict
-    >>> class HostDict(modifiable_items_dict.ModifiableItemsDict):
+    >>> import modifiable_items_dictionary
+    >>> class HostDict(modifiable_items_dictionary.ModifiableItemsDict):
     ...     _key_modifiers = (str.casefold, str.strip)
     ...     _value_modifiers = [ipaddress.ip_address]
     >>> browsers = HostDict({"  GooGle.com    ": "142.250.69.206", " duckDUCKGo.cOM   ": "52.250.42.157"})

--- a/modifiable_items_dictionary/modifiable_items_dictionary.py
+++ b/modifiable_items_dictionary/modifiable_items_dictionary.py
@@ -3,7 +3,6 @@ Modifiable Items Dictionary and related objects.
 
 Example:
     >>> import ipaddress
-    >>> from modifiable_items_dictionary.modifiable_items_dictionary import ModifiableItemsDict
     >>> class HostDict(ModifiableItemsDict):
     ...     _key_modifiers = (str.casefold, str.strip)
     ...     _value_modifiers = [ipaddress.ip_address]

--- a/modifiable_items_dictionary/modifiable_items_dictionary.py
+++ b/modifiable_items_dictionary/modifiable_items_dictionary.py
@@ -3,8 +3,8 @@ Modifiable Items Dictionary and related objects.
 
 Example:
     >>> import ipaddress
-    >>> import modifiable_items_dictionary
-    >>> class HostDict(modifiable_items_dictionary.ModifiableItemsDict):
+    >>> from modifiable_items_dictionary.modifiable_items_dictionary import ModifiableItemsDict
+    >>> class HostDict(ModifiableItemsDict):
     ...     _key_modifiers = (str.casefold, str.strip)
     ...     _value_modifiers = [ipaddress.ip_address]
     >>> browsers = HostDict({"  GooGle.com    ": "142.250.69.206", " duckDUCKGo.cOM   ": "52.250.42.157"})

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,14 @@
 """Setup.py"""
-from setuptools import (
-    find_packages,
-    setup,
-)
+import setuptools
 
-__version__ = "v1.0.1"
+__version__ = "v1.0.2"
 __author__ = "Tyler Bruno"
 _description = "Typed and Tested Modifiable Items Dict which allows keys and values to be modified at run time."
 
 with open("README.md", "r", encoding="utf-8") as file:
     README = file.read()
 
-setup(
+setuptools.setup(
     name="modifiable-items-dictionary",
     version=__version__,
     author=__author__,
@@ -22,7 +19,7 @@ setup(
     url="https://github.com/tybruno/modifiable-items-dictionary",
     license="MIT",
     package_data={"modifiable-items-dictionary": ["py.typed"]},
-    packages=find_packages(),
+    packages=setuptools.find_packages(),
     install_requires=[],
     classifiers=[
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """Setup.py"""
 import setuptools
 
-__version__ = "v1.0.2"
+__version__ = "v2.0.0"
 __author__ = "Tyler Bruno"
 _description = "Typed and Tested Modifiable Items Dict which allows keys and values to be modified at run time."
 
@@ -15,7 +15,7 @@ setuptools.setup(
     description=_description,
     long_description=README,
     long_description_content_type="text/markdown",
-    keywords="python dict dictionary",
+    keywords="python dict dictionary mapping key-mangling",
     url="https://github.com/tybruno/modifiable-items-dictionary",
     license="MIT",
     package_data={"modifiable-items-dictionary": ["py.typed"]},

--- a/tests/test_modifiable_items_dict.py
+++ b/tests/test_modifiable_items_dict.py
@@ -1,49 +1,36 @@
 import contextlib
 import ipaddress
-from copy import deepcopy
-from typing import (
-    Mapping,
-    Any,
-    NamedTuple,
-    Union,
-    Type,
-    Iterable,
-    Tuple,
-    Hashable,
-)
+import copy
+import typing
 
 import pytest
 
-from modifiable_items_dict.modifiable_items_dict import (
-    ModifiableItemsDict,
-    _KEY_CALLABLE,
-    _VALUE_CALLABLE,
-)
+import modifiable_items_dict
 
 
-def _strip(_value: Any):
+def _strip(_value: typing.Any):
     if isinstance(_value, str):
         _value = _value.strip()
         return _value
     return _value
 
 
-def _case_fold(_value: Any) -> Any:
+def _case_fold(_value: typing.Any) -> typing.Any:
     if isinstance(_value, str):
         _case_folded_string: str = _value.casefold()
         return _case_folded_string
     return _value
 
 
-def _strip_and_case_fold(_value: Any) -> Any:
+def _strip_and_case_fold(_value: typing.Any) -> typing.Any:
     _value = _case_fold(_strip(_value))
     return _value
 
 
-def _to_ipaddress(_value: Any) -> Any:
+def _to_ipaddress(_value: typing.Any) -> typing.Any:
     if isinstance(_value, str):
         with contextlib.suppress(ValueError):
-            _ip_address: Union[
+            _ip_address: typing.Union[
                 ipaddress.IPv4Address, ipaddress.IPv6Address
             ] = ipaddress.ip_address(_value)
             return _ip_address
@@ -64,40 +51,40 @@ def _to_ipaddress(_value: Any) -> Any:
         {1: 2, ("hello", "Goodbye"): 2},
     )
 )
-def valid_mapping(request) -> Mapping:
-    inputs: Mapping = request.param
+def valid_mapping(request) -> typing.Mapping:
+    inputs: typing.Mapping = request.param
     return inputs
 
 
-class HostDict(ModifiableItemsDict):
+class HostDict(modifiable_items_dict.ModifiableItemsDict):
     _key_modifiers = [_strip, _case_fold]
     _value_modifiers = staticmethod(_to_ipaddress)
 
 
-class _TestingClass(NamedTuple):
-    cls: Type[ModifiableItemsDict]
-    modify_key: _KEY_CALLABLE
-    modify_value: _VALUE_CALLABLE
+class _TestingClass(typing.NamedTuple):
+    cls: typing.Type[modifiable_items_dict.ModifiableItemsDict]
+    modify_key: modifiable_items_dict.modifiable_items_dict.KeyCallable
+    modify_value: modifiable_items_dict.modifiable_items_dict.ValueCallable
 
 
-def host_dict_with_list_and_static_method_modifiers() -> Type[
-    ModifiableItemsDict
+def host_dict_with_list_and_static_method_modifiers() -> typing.Type[
+    modifiable_items_dict.ModifiableItemsDict
 ]:
-    class HostDict(ModifiableItemsDict):
+    class HostDict(modifiable_items_dict.ModifiableItemsDict):
         _key_modifiers = [_strip, _case_fold]
         _value_modifiers = staticmethod(_to_ipaddress)
 
     return HostDict
 
 
-def host_dict_with_list_and_method_modifiers() -> Type[ModifiableItemsDict]:
-    class HostDict(ModifiableItemsDict):
+def host_dict_with_list_and_method_modifiers() -> typing.Type[modifiable_items_dict.ModifiableItemsDict]:
+    class HostDict(modifiable_items_dict.ModifiableItemsDict):
         _key_modifiers = [_strip, _case_fold]
 
-        def _value_modifiers(self, _value: Any) -> Any:
+        def _value_modifiers(self, _value: typing.Any) -> typing.Any:
             if isinstance(_value, str):
                 with contextlib.suppress(ValueError):
-                    _ip_address: Union[
+                    _ip_address: typing.Union[
                         ipaddress.IPv4Address, ipaddress.IPv6Address
                     ] = ipaddress.ip_address(_value)
                     return _ip_address
@@ -119,7 +106,7 @@ def host_dict_with_list_and_method_modifiers() -> Type[ModifiableItemsDict]:
             _strip_and_case_fold,
             _to_ipaddress,
         ),
-        _TestingClass(ModifiableItemsDict, lambda x: x, lambda x : x)
+        _TestingClass(modifiable_items_dict.ModifiableItemsDict, lambda x: x, lambda x : x)
     )
 )
 def class_under_test(request) -> _TestingClass:
@@ -133,8 +120,8 @@ def class_under_test(request) -> _TestingClass:
         [(" GooGle.com ", "142.250.69.206"), ("CisCO", "72.163.4.185")],
     ]
 )
-def hosts(request) -> Mapping:
-    _hosts: Mapping = request.param
+def hosts(request) -> typing.Mapping:
+    _hosts: typing.Mapping = request.param
     return _hosts
 
 
@@ -147,21 +134,21 @@ def unhashable_type(request):
 class TestModifiableItemsDict:
     @pytest.mark.parametrize("bad_modifiers", [1, 7.62, "string"])
     def test_bad_modifiers(self, bad_modifiers):
-        class BadModifierTest(ModifiableItemsDict):
+        class BadModifierTest(modifiable_items_dict.ModifiableItemsDict):
             _key_modifiers = bad_modifiers
 
         with pytest.raises(TypeError):
             BadModifierTest(a=1)
 
     def test_modifiers_is_none(self, valid_mapping):
-        class NoModifiersDict(ModifiableItemsDict):
+        class NoModifiersDict(modifiable_items_dict.ModifiableItemsDict):
             _key_modifiers = None
             _value_modifiers = None
         expected = valid_mapping
         actual = NoModifiersDict(valid_mapping)
         assert actual == expected
 
-    def test__init__mapping(self, valid_mapping: Mapping, class_under_test):
+    def test__init__mapping(self, valid_mapping: typing.Mapping, class_under_test):
         _class, _key_operation, _value_operation = class_under_test
 
         modifiable_dict = _class(valid_mapping)
@@ -175,10 +162,10 @@ class TestModifiableItemsDict:
         "valid_kwargs",
         ({"a": 1, "B": 2}, {"lower": 3, "UPPER": 4, "MiXeD": 5}),
     )
-    def test__init__kwargs(self, valid_kwargs: Mapping, class_under_test):
+    def test__init__kwargs(self, valid_kwargs: typing.Mapping, class_under_test):
         _class, _key_operation, _value_operation = class_under_test
 
-        modifiable_items_dictionary = _class(**valid_kwargs)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(**valid_kwargs)
         expected = {
             _key_operation(key): _value_operation(value)
             for key, value in valid_kwargs.items()
@@ -192,7 +179,7 @@ class TestModifiableItemsDict:
         ],
     )
     def test__init__iterable_and_kwargs(
-        self, mapping_and_kwargs: Tuple[Mapping, Mapping], class_under_test
+        self, mapping_and_kwargs: typing.Tuple[typing.Mapping, typing.Mapping], class_under_test
     ):
         _class, _key_operation, _value_operation = class_under_test
         args, kwargs = mapping_and_kwargs
@@ -200,7 +187,7 @@ class TestModifiableItemsDict:
             _key_operation(key): _value_operation(value)
             for key, value in dict(**args, **kwargs).items()
         }
-        modifiable_items_dictionary = _class(args, **kwargs)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(args, **kwargs)
         assert modifiable_items_dictionary == expected
 
     @pytest.mark.parametrize(
@@ -211,12 +198,12 @@ class TestModifiableItemsDict:
         ],
     )
     def test__init__iterable(
-        self, iterables: Iterable[Tuple[Hashable, Any]], class_under_test
+        self, iterables: typing.Iterable[typing.Tuple[typing.Hashable, typing.Any]], class_under_test
     ):
         _class, _key_operation, _value_operation = class_under_test
-        iterables_copy = deepcopy(iterables)
-        modifiable_items_dictionary = _class(iterables)
-        expected: Mapping = {
+        iterables_copy = copy.deepcopy(iterables)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(iterables)
+        expected: typing.Mapping = {
             _key_operation(key): _value_operation(value)
             for key, value in iterables_copy
         }
@@ -241,15 +228,15 @@ class TestModifiableItemsDict:
         "keys",
         (["lower", "Title", "UPPER", "CamelCase", "snake_case", object()],),
     )
-    def test_fromkeys(self, keys: Iterable, class_under_test):
+    def test_fromkeys(self, keys: typing.Iterable, class_under_test):
         _class, _key_operation, _value_operation = class_under_test
 
         value = "Some Value"
-        expected: Mapping = {
+        expected: typing.Mapping = {
             _key_operation(key): _value_operation(value) for key in keys
         }
 
-        modifiable_items_dictionary = _class.fromkeys(keys, value)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class.fromkeys(keys, value)
         assert modifiable_items_dictionary == expected
         assert isinstance(modifiable_items_dictionary, _class)
 
@@ -260,14 +247,14 @@ class TestModifiableItemsDict:
         "keys",
         (["lower", "Title", "UPPER", "CamelCase", "snake_case", object()],),
     )
-    def test_fromkeys_none_value(self, keys: Iterable, class_under_test):
+    def test_fromkeys_none_value(self, keys: typing.Iterable, class_under_test):
         _class, _key_operation, _value_operation = class_under_test
 
-        expected: Mapping = {
+        expected: typing.Mapping = {
             _key_operation(key): _value_operation(None) for key in keys
         }
 
-        modifiable_items_dictionary = _class.fromkeys(keys)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class.fromkeys(keys)
         assert modifiable_items_dictionary == expected
         assert isinstance(modifiable_items_dictionary, _class)
 
@@ -295,21 +282,21 @@ class TestModifiableItemsDict:
     def test___setitem__bad_key_type(self, unhashable_type, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class()
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
         with pytest.raises(TypeError):
             modifiable_items_dictionary[unhashable_type] = 0
 
     def test__getitem__(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class(valid_mapping)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
         for key, value in valid_mapping.items():
             assert modifiable_items_dictionary[key] == value
 
     def test__getitem__missing_key(self, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class()
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
         assert modifiable_items_dictionary == dict()
 
         # make unique __key which will not be in dict
@@ -321,7 +308,7 @@ class TestModifiableItemsDict:
     def test__delitem__(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class(valid_mapping)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
         for key, value in valid_mapping.items():
             del modifiable_items_dictionary[key]
             assert key not in modifiable_items_dictionary
@@ -329,14 +316,14 @@ class TestModifiableItemsDict:
     def test__delitem__missing_key(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class(valid_mapping)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
         with contextlib.suppress(KeyError):
             del modifiable_items_dictionary["missing_key"]
 
     def test_get(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class(valid_mapping)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
         for key, value in valid_mapping.items():
             assert modifiable_items_dictionary.get(key) == value
             assert modifiable_items_dictionary.get(key, None) == value
@@ -344,7 +331,7 @@ class TestModifiableItemsDict:
     def test_get_missing_key(self, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class()
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
 
         # make unique __key which will not be in dict
         _missing_key = object()
@@ -359,7 +346,7 @@ class TestModifiableItemsDict:
     def test_get_unhashable_key(self, unhashable_type, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class()
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
 
         _default = "__default v"
 
@@ -370,7 +357,7 @@ class TestModifiableItemsDict:
     def test_pop(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class(valid_mapping)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
         for key, value in valid_mapping.items():
             assert modifiable_items_dictionary.pop(key) == value
             assert key not in modifiable_items_dictionary
@@ -378,17 +365,16 @@ class TestModifiableItemsDict:
     def test_pop_default(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class(valid_mapping)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
         _missing_key = object()
         _default = "default value"
-
 
         assert modifiable_items_dictionary.pop(_missing_key, _default) == _default
 
     def test_pop_missing_key(self, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class()
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
 
         # make unique __key which will not be in dict
         _missing_key = object()
@@ -399,7 +385,7 @@ class TestModifiableItemsDict:
     def test_pop_unhashable_type(self, class_under_test, unhashable_type):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: _class = _class()
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
 
         with pytest.raises(KeyError):
             modifiable_items_dictionary.pop(unhashable_type)
@@ -407,7 +393,7 @@ class TestModifiableItemsDict:
     def test_setdefault(self, valid_mapping, class_under_test):
         _class, _key_operation, _value_operation = class_under_test
 
-        modifiable_items_dict: _class = _class()
+        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict= _class()
         expected: dict = dict()
         for key, item in valid_mapping.items():
             expected.setdefault(_key_operation(key), _value_operation(item))
@@ -420,7 +406,7 @@ class TestModifiableItemsDict:
     ):
         _class, _, _ = class_under_test
 
-        modifiable_items_dict: _class = _class()
+        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict = _class()
 
         with pytest.raises(TypeError):
             modifiable_items_dict.setdefault(unhashable_type)
@@ -436,7 +422,7 @@ class TestModifiableItemsDict:
         self, class_under_test, starting_data, args, kwargs
     ):
         _class, _key_operation, _value_operation = class_under_test
-        modifiable_items_dict: _class = _class(starting_data)
+        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict = _class(starting_data)
 
         expected = dict(
             {
@@ -474,7 +460,7 @@ class TestModifiableItemsDict:
         self, class_under_test, starting_data, args, kwargs
     ):
         _class, _key_operation, _value_operation = class_under_test
-        modifiable_items_dict: _class = _class(starting_data)
+        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict = _class(starting_data)
 
         expected = dict(
             {
@@ -502,7 +488,7 @@ class TestModifiableItemsDict:
 
     def test_update_unhashable_key(self, class_under_test, unhashable_type):
         _class, _, _ = class_under_test
-        modifiable_items_dict: _class = _class()
+        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict = _class()
 
         iterable = [(unhashable_type, 1)]
 
@@ -512,7 +498,7 @@ class TestModifiableItemsDict:
     @pytest.mark.parametrize("iterable", [[("1", 1), ("two", 2, 2)]])
     def test_update_bad_iterable_value(self, class_under_test, iterable):
         _class, _, _ = class_under_test
-        modifiable_items_dict: _class = _class()
+        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict = _class()
 
         with pytest.raises(ValueError):
             modifiable_items_dict.update(iterable)

--- a/tests/test_modifiable_items_dict.py
+++ b/tests/test_modifiable_items_dict.py
@@ -1,6 +1,6 @@
 import contextlib
-import ipaddress
 import copy
+import ipaddress
 import typing
 
 import pytest
@@ -40,15 +40,15 @@ def _to_ipaddress(_value: typing.Any) -> typing.Any:
 
 @pytest.fixture(
     params=(
-        {
-            "CamelCase": 1,
-            "lower": 2,
-            "UPPER": 3,
-            "snake_case": 4,
-            5: "Five",
-            True: "True",
-        },
-        {1: 2, ("hello", "Goodbye"): 2},
+            {
+                "CamelCase": 1,
+                "lower": 2,
+                "UPPER": 3,
+                "snake_case": 4,
+                5: "Five",
+                True: "True",
+            },
+            {1: 2, ("hello", "Goodbye"): 2},
     )
 )
 def valid_mapping(request) -> typing.Mapping:
@@ -96,17 +96,17 @@ def host_dict_with_list_and_method_modifiers() -> typing.Type[modifiable_items_d
 
 @pytest.fixture(
     params=(
-        _TestingClass(
-            host_dict_with_list_and_static_method_modifiers(),
-            _strip_and_case_fold,
-            _to_ipaddress,
-        ),
-        _TestingClass(
-            host_dict_with_list_and_method_modifiers(),
-            _strip_and_case_fold,
-            _to_ipaddress,
-        ),
-        _TestingClass(modifiable_items_dict.ModifiableItemsDict, lambda x: x, lambda x : x)
+            _TestingClass(
+                host_dict_with_list_and_static_method_modifiers(),
+                _strip_and_case_fold,
+                _to_ipaddress,
+            ),
+            _TestingClass(
+                host_dict_with_list_and_method_modifiers(),
+                _strip_and_case_fold,
+                _to_ipaddress,
+            ),
+            _TestingClass(modifiable_items_dict.ModifiableItemsDict, lambda x: x, lambda x: x)
     )
 )
 def class_under_test(request) -> _TestingClass:
@@ -144,6 +144,7 @@ class TestModifiableItemsDict:
         class NoModifiersDict(modifiable_items_dict.ModifiableItemsDict):
             _key_modifiers = None
             _value_modifiers = None
+
         expected = valid_mapping
         actual = NoModifiersDict(valid_mapping)
         assert actual == expected
@@ -179,7 +180,7 @@ class TestModifiableItemsDict:
         ],
     )
     def test__init__iterable_and_kwargs(
-        self, mapping_and_kwargs: typing.Tuple[typing.Mapping, typing.Mapping], class_under_test
+            self, mapping_and_kwargs: typing.Tuple[typing.Mapping, typing.Mapping], class_under_test
     ):
         _class, _key_operation, _value_operation = class_under_test
         args, kwargs = mapping_and_kwargs
@@ -198,7 +199,7 @@ class TestModifiableItemsDict:
         ],
     )
     def test__init__iterable(
-        self, iterables: typing.Iterable[typing.Tuple[typing.Hashable, typing.Any]], class_under_test
+            self, iterables: typing.Iterable[typing.Tuple[typing.Hashable, typing.Any]], class_under_test
     ):
         _class, _key_operation, _value_operation = class_under_test
         iterables_copy = copy.deepcopy(iterables)
@@ -339,8 +340,8 @@ class TestModifiableItemsDict:
 
         assert modifiable_items_dictionary.get(_missing_key) is None
         assert (
-            modifiable_items_dictionary.get(_missing_key, _default)
-            == _default
+                modifiable_items_dictionary.get(_missing_key, _default)
+                == _default
         )
 
     def test_get_unhashable_key(self, unhashable_type, class_under_test):
@@ -393,23 +394,23 @@ class TestModifiableItemsDict:
     def test_setdefault(self, valid_mapping, class_under_test):
         _class, _key_operation, _value_operation = class_under_test
 
-        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict= _class()
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
         expected: dict = dict()
         for key, item in valid_mapping.items():
             expected.setdefault(_key_operation(key), _value_operation(item))
-            modifiable_items_dict.setdefault(key, item)
-        assert modifiable_items_dict == expected
-        assert repr(modifiable_items_dict) == repr(expected)
+            modifiable_items_dictionary.setdefault(key, item)
+        assert modifiable_items_dictionary == expected
+        assert repr(modifiable_items_dictionary) == repr(expected)
 
     def test_setdefault_unhashable_type(
-        self, class_under_test, unhashable_type
+            self, class_under_test, unhashable_type
     ):
         _class, _, _ = class_under_test
 
-        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
 
         with pytest.raises(TypeError):
-            modifiable_items_dict.setdefault(unhashable_type)
+            modifiable_items_dictionary.setdefault(unhashable_type)
 
     @pytest.mark.parametrize(
         "starting_data", ({"start_lower": 1, "START_UPPER": 2, "__key": 1},)
@@ -419,10 +420,10 @@ class TestModifiableItemsDict:
     )
     @pytest.mark.parametrize("kwargs", ({"UP": 1, "down": 2, "__key": 3},))
     def test_update_using_mapping(
-        self, class_under_test, starting_data, args, kwargs
+            self, class_under_test, starting_data, args, kwargs
     ):
         _class, _key_operation, _value_operation = class_under_test
-        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict = _class(starting_data)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(starting_data)
 
         expected = dict(
             {
@@ -431,7 +432,7 @@ class TestModifiableItemsDict:
             }
         )
 
-        assert modifiable_items_dict == expected
+        assert modifiable_items_dictionary == expected
 
         expected.update(
             {
@@ -444,9 +445,9 @@ class TestModifiableItemsDict:
             }
         )
 
-        modifiable_items_dict.update(args, **kwargs)
+        modifiable_items_dictionary.update(args, **kwargs)
 
-        assert modifiable_items_dict == expected
+        assert modifiable_items_dictionary == expected
 
     @pytest.mark.parametrize(
         "starting_data", ({"start_lower": 1, "START_UPPER": 2, "__key": 1},)
@@ -457,10 +458,10 @@ class TestModifiableItemsDict:
     )
     @pytest.mark.parametrize("kwargs", ({"UP": 1, "down": 2, "__key": 3},))
     def test_update_using_sequence(
-        self, class_under_test, starting_data, args, kwargs
+            self, class_under_test, starting_data, args, kwargs
     ):
         _class, _key_operation, _value_operation = class_under_test
-        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict = _class(starting_data)
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(starting_data)
 
         expected = dict(
             {
@@ -469,7 +470,7 @@ class TestModifiableItemsDict:
             }
         )
 
-        assert modifiable_items_dict == expected
+        assert modifiable_items_dictionary == expected
 
         expected.update(
             {
@@ -482,23 +483,23 @@ class TestModifiableItemsDict:
             }
         )
 
-        modifiable_items_dict.update(args, **kwargs)
+        modifiable_items_dictionary.update(args, **kwargs)
 
-        assert modifiable_items_dict == expected
+        assert modifiable_items_dictionary == expected
 
     def test_update_unhashable_key(self, class_under_test, unhashable_type):
         _class, _, _ = class_under_test
-        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
 
         iterable = [(unhashable_type, 1)]
 
         with pytest.raises(TypeError):
-            modifiable_items_dict.update(iterable)
+            modifiable_items_dictionary.update(iterable)
 
     @pytest.mark.parametrize("iterable", [[("1", 1), ("two", 2, 2)]])
     def test_update_bad_iterable_value(self, class_under_test, iterable):
         _class, _, _ = class_under_test
-        modifiable_items_dict: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
 
         with pytest.raises(ValueError):
-            modifiable_items_dict.update(iterable)
+            modifiable_items_dictionary.update(iterable)

--- a/tests/test_modifiable_items_dict.py
+++ b/tests/test_modifiable_items_dict.py
@@ -5,8 +5,8 @@ import typing
 
 import pytest
 
-import modifiable_items_dict
-import modifiable_items_dict.modifiable_items_dict
+import modifiable_items_dictionary
+import modifiable_items_dictionary.modifiable_items_dictionary
 
 def _strip(_value: typing.Any):
     if isinstance(_value, str):
@@ -56,29 +56,29 @@ def valid_mapping(request) -> typing.Mapping:
     return inputs
 
 
-class HostDict(modifiable_items_dict.ModifiableItemsDict):
+class HostDict(modifiable_items_dictionary.ModifiableItemsDict):
     _key_modifiers = [_strip, _case_fold]
     _value_modifiers = staticmethod(_to_ipaddress)
 
 
 class _TestingClass(typing.NamedTuple):
-    cls: typing.Type[modifiable_items_dict.ModifiableItemsDict]
-    modify_key: modifiable_items_dict.modifiable_items_dict.KeyCallable
-    modify_value: modifiable_items_dict.modifiable_items_dict.ValueCallable
+    cls: typing.Type[modifiable_items_dictionary.ModifiableItemsDict]
+    modify_key: modifiable_items_dictionary.modifiable_items_dictionary.KeyCallable
+    modify_value: modifiable_items_dictionary.modifiable_items_dictionary.ValueCallable
 
 
 def host_dict_with_list_and_static_method_modifiers() -> typing.Type[
-    modifiable_items_dict.ModifiableItemsDict
+    modifiable_items_dictionary.ModifiableItemsDict
 ]:
-    class HostDict(modifiable_items_dict.ModifiableItemsDict):
+    class HostDict(modifiable_items_dictionary.ModifiableItemsDict):
         _key_modifiers = [_strip, _case_fold]
         _value_modifiers = staticmethod(_to_ipaddress)
 
     return HostDict
 
 
-def host_dict_with_list_and_method_modifiers() -> typing.Type[modifiable_items_dict.ModifiableItemsDict]:
-    class HostDict(modifiable_items_dict.ModifiableItemsDict):
+def host_dict_with_list_and_method_modifiers() -> typing.Type[modifiable_items_dictionary.ModifiableItemsDict]:
+    class HostDict(modifiable_items_dictionary.ModifiableItemsDict):
         _key_modifiers = [_strip, _case_fold]
 
         def _value_modifiers(self, _value: typing.Any) -> typing.Any:
@@ -106,7 +106,7 @@ def host_dict_with_list_and_method_modifiers() -> typing.Type[modifiable_items_d
                 _strip_and_case_fold,
                 _to_ipaddress,
             ),
-            _TestingClass(modifiable_items_dict.ModifiableItemsDict, lambda x: x, lambda x: x)
+            _TestingClass(modifiable_items_dictionary.ModifiableItemsDict, lambda x: x, lambda x: x)
     )
 )
 def class_under_test(request) -> _TestingClass:
@@ -134,14 +134,14 @@ def unhashable_type(request):
 class TestModifiableItemsDict:
     @pytest.mark.parametrize("bad_modifiers", [1, 7.62, "string"])
     def test_bad_modifiers(self, bad_modifiers):
-        class BadModifierTest(modifiable_items_dict.ModifiableItemsDict):
+        class BadModifierTest(modifiable_items_dictionary.ModifiableItemsDict):
             _key_modifiers = bad_modifiers
 
         with pytest.raises(TypeError):
             BadModifierTest(a=1)
 
     def test_modifiers_is_none(self, valid_mapping):
-        class NoModifiersDict(modifiable_items_dict.ModifiableItemsDict):
+        class NoModifiersDict(modifiable_items_dictionary.ModifiableItemsDict):
             _key_modifiers = None
             _value_modifiers = None
 
@@ -166,12 +166,12 @@ class TestModifiableItemsDict:
     def test__init__kwargs(self, valid_kwargs: typing.Mapping, class_under_test):
         _class, _key_operation, _value_operation = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(**valid_kwargs)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(**valid_kwargs)
         expected = {
             _key_operation(key): _value_operation(value)
             for key, value in valid_kwargs.items()
         }
-        assert modifiable_items_dictionary == expected
+        assert modifiable_items_dict == expected
 
     @pytest.mark.parametrize(
         "mapping_and_kwargs",
@@ -188,8 +188,8 @@ class TestModifiableItemsDict:
             _key_operation(key): _value_operation(value)
             for key, value in dict(**args, **kwargs).items()
         }
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(args, **kwargs)
-        assert modifiable_items_dictionary == expected
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(args, **kwargs)
+        assert modifiable_items_dict == expected
 
     @pytest.mark.parametrize(
         "iterables",
@@ -203,13 +203,13 @@ class TestModifiableItemsDict:
     ):
         _class, _key_operation, _value_operation = class_under_test
         iterables_copy = copy.deepcopy(iterables)
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(iterables)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(iterables)
         expected: typing.Mapping = {
             _key_operation(key): _value_operation(value)
             for key, value in iterables_copy
         }
-        assert modifiable_items_dictionary == expected
-        assert repr(modifiable_items_dictionary) == repr(expected)
+        assert modifiable_items_dict == expected
+        assert repr(modifiable_items_dict) == repr(expected)
 
     @pytest.mark.parametrize("invalid_type", ([1], {2}, True, 1))
     def test__init__invalid_type(self, invalid_type, class_under_test):
@@ -237,12 +237,12 @@ class TestModifiableItemsDict:
             _key_operation(key): _value_operation(value) for key in keys
         }
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class.fromkeys(keys, value)
-        assert modifiable_items_dictionary == expected
-        assert isinstance(modifiable_items_dictionary, _class)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class.fromkeys(keys, value)
+        assert modifiable_items_dict == expected
+        assert isinstance(modifiable_items_dict, _class)
 
         for key in keys:
-            assert key in modifiable_items_dictionary
+            assert key in modifiable_items_dict
 
     @pytest.mark.parametrize(
         "keys",
@@ -255,12 +255,12 @@ class TestModifiableItemsDict:
             _key_operation(key): _value_operation(None) for key in keys
         }
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class.fromkeys(keys)
-        assert modifiable_items_dictionary == expected
-        assert isinstance(modifiable_items_dictionary, _class)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class.fromkeys(keys)
+        assert modifiable_items_dict == expected
+        assert isinstance(modifiable_items_dict, _class)
 
         for key in keys:
-            assert key in modifiable_items_dictionary
+            assert key in modifiable_items_dict
 
     @pytest.mark.parametrize("invalid_type", (True, 1))
     def test_fromkeys_with_invalid_type(self, invalid_type, class_under_test):
@@ -283,134 +283,134 @@ class TestModifiableItemsDict:
     def test___setitem__bad_key_type(self, unhashable_type, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class()
         with pytest.raises(TypeError):
-            modifiable_items_dictionary[unhashable_type] = 0
+            modifiable_items_dict[unhashable_type] = 0
 
     def test__getitem__(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(valid_mapping)
         for key, value in valid_mapping.items():
-            assert modifiable_items_dictionary[key] == value
+            assert modifiable_items_dict[key] == value
 
     def test__getitem__missing_key(self, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
-        assert modifiable_items_dictionary == dict()
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class()
+        assert modifiable_items_dict == dict()
 
         # make unique __key which will not be in dict
         _missing_key = object()
 
         with pytest.raises(KeyError):
-            _ = modifiable_items_dictionary[_missing_key]
+            _ = modifiable_items_dict[_missing_key]
 
     def test__delitem__(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(valid_mapping)
         for key, value in valid_mapping.items():
-            del modifiable_items_dictionary[key]
-            assert key not in modifiable_items_dictionary
+            del modifiable_items_dict[key]
+            assert key not in modifiable_items_dict
 
     def test__delitem__missing_key(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(valid_mapping)
         with contextlib.suppress(KeyError):
-            del modifiable_items_dictionary["missing_key"]
+            del modifiable_items_dict["missing_key"]
 
     def test_get(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(valid_mapping)
         for key, value in valid_mapping.items():
-            assert modifiable_items_dictionary.get(key) == value
-            assert modifiable_items_dictionary.get(key, None) == value
+            assert modifiable_items_dict.get(key) == value
+            assert modifiable_items_dict.get(key, None) == value
 
     def test_get_missing_key(self, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class()
 
         # make unique __key which will not be in dict
         _missing_key = object()
         _default = "__default v"
 
-        assert modifiable_items_dictionary.get(_missing_key) is None
+        assert modifiable_items_dict.get(_missing_key) is None
         assert (
-                modifiable_items_dictionary.get(_missing_key, _default)
+                modifiable_items_dict.get(_missing_key, _default)
                 == _default
         )
 
     def test_get_unhashable_key(self, unhashable_type, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class()
 
         _default = "__default v"
 
         with pytest.raises(TypeError):
-            modifiable_items_dictionary.get(unhashable_type)
-            modifiable_items_dictionary.get(unhashable_type, _default)
+            modifiable_items_dict.get(unhashable_type)
+            modifiable_items_dict.get(unhashable_type, _default)
 
     def test_pop(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(valid_mapping)
         for key, value in valid_mapping.items():
-            assert modifiable_items_dictionary.pop(key) == value
-            assert key not in modifiable_items_dictionary
+            assert modifiable_items_dict.pop(key) == value
+            assert key not in modifiable_items_dict
 
     def test_pop_default(self, valid_mapping, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(valid_mapping)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(valid_mapping)
         _missing_key = object()
         _default = "default value"
 
-        assert modifiable_items_dictionary.pop(_missing_key, _default) == _default
+        assert modifiable_items_dict.pop(_missing_key, _default) == _default
 
     def test_pop_missing_key(self, class_under_test):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class()
 
         # make unique __key which will not be in dict
         _missing_key = object()
 
         with pytest.raises(KeyError):
-            modifiable_items_dictionary.pop(_missing_key)
+            modifiable_items_dict.pop(_missing_key)
 
     def test_pop_unhashable_type(self, class_under_test, unhashable_type):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class()
 
         with pytest.raises(KeyError):
-            modifiable_items_dictionary.pop(unhashable_type)
+            modifiable_items_dict.pop(unhashable_type)
 
     def test_setdefault(self, valid_mapping, class_under_test):
         _class, _key_operation, _value_operation = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class()
         expected: dict = dict()
         for key, item in valid_mapping.items():
             expected.setdefault(_key_operation(key), _value_operation(item))
-            modifiable_items_dictionary.setdefault(key, item)
-        assert modifiable_items_dictionary == expected
-        assert repr(modifiable_items_dictionary) == repr(expected)
+            modifiable_items_dict.setdefault(key, item)
+        assert modifiable_items_dict == expected
+        assert repr(modifiable_items_dict) == repr(expected)
 
     def test_setdefault_unhashable_type(
             self, class_under_test, unhashable_type
     ):
         _class, _, _ = class_under_test
 
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class()
 
         with pytest.raises(TypeError):
-            modifiable_items_dictionary.setdefault(unhashable_type)
+            modifiable_items_dict.setdefault(unhashable_type)
 
     @pytest.mark.parametrize(
         "starting_data", ({"start_lower": 1, "START_UPPER": 2, "__key": 1},)
@@ -423,7 +423,7 @@ class TestModifiableItemsDict:
             self, class_under_test, starting_data, args, kwargs
     ):
         _class, _key_operation, _value_operation = class_under_test
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(starting_data)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(starting_data)
 
         expected = dict(
             {
@@ -432,7 +432,7 @@ class TestModifiableItemsDict:
             }
         )
 
-        assert modifiable_items_dictionary == expected
+        assert modifiable_items_dict == expected
 
         expected.update(
             {
@@ -445,9 +445,9 @@ class TestModifiableItemsDict:
             }
         )
 
-        modifiable_items_dictionary.update(args, **kwargs)
+        modifiable_items_dict.update(args, **kwargs)
 
-        assert modifiable_items_dictionary == expected
+        assert modifiable_items_dict == expected
 
     @pytest.mark.parametrize(
         "starting_data", ({"start_lower": 1, "START_UPPER": 2, "__key": 1},)
@@ -461,7 +461,7 @@ class TestModifiableItemsDict:
             self, class_under_test, starting_data, args, kwargs
     ):
         _class, _key_operation, _value_operation = class_under_test
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class(starting_data)
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class(starting_data)
 
         expected = dict(
             {
@@ -470,7 +470,7 @@ class TestModifiableItemsDict:
             }
         )
 
-        assert modifiable_items_dictionary == expected
+        assert modifiable_items_dict == expected
 
         expected.update(
             {
@@ -483,23 +483,23 @@ class TestModifiableItemsDict:
             }
         )
 
-        modifiable_items_dictionary.update(args, **kwargs)
+        modifiable_items_dict.update(args, **kwargs)
 
-        assert modifiable_items_dictionary == expected
+        assert modifiable_items_dict == expected
 
     def test_update_unhashable_key(self, class_under_test, unhashable_type):
         _class, _, _ = class_under_test
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class()
 
         iterable = [(unhashable_type, 1)]
 
         with pytest.raises(TypeError):
-            modifiable_items_dictionary.update(iterable)
+            modifiable_items_dict.update(iterable)
 
     @pytest.mark.parametrize("iterable", [[("1", 1), ("two", 2, 2)]])
     def test_update_bad_iterable_value(self, class_under_test, iterable):
         _class, _, _ = class_under_test
-        modifiable_items_dictionary: modifiable_items_dict.ModifiableItemsDict = _class()
+        modifiable_items_dict: modifiable_items_dictionary.ModifiableItemsDict = _class()
 
         with pytest.raises(ValueError):
-            modifiable_items_dictionary.update(iterable)
+            modifiable_items_dict.update(iterable)

--- a/tests/test_modifiable_items_dict.py
+++ b/tests/test_modifiable_items_dict.py
@@ -6,7 +6,7 @@ import typing
 import pytest
 
 import modifiable_items_dict
-
+import modifiable_items_dict.modifiable_items_dict
 
 def _strip(_value: typing.Any):
     if isinstance(_value, str):


### PR DESCRIPTION
- Cleaning up typing as variables to match pep 8 standards
- Added more examples in `examply.py` and cleaned up the examples
- Refactored imports to use `import` instead of `from` to cleanup namespace.